### PR TITLE
Added reset() method to DataCollector

### DIFF
--- a/lib/Onurb/Bundle/YumlBundle/DataCollector/DoctrineYumlDataCollector.php
+++ b/lib/Onurb/Bundle/YumlBundle/DataCollector/DoctrineYumlDataCollector.php
@@ -16,4 +16,9 @@ class DoctrineYumlDataCollector extends DataCollector
     {
         return 'doctrine_yuml';
     }
+    
+    public function reset()
+    {
+        $this->data = array();
+    }
 }


### PR DESCRIPTION
This removes a Symfony 3.4 deprecation notice. It's a first step towards SF4 compatibility.

See issue #2 